### PR TITLE
Make busy rx/tx loop faster.

### DIFF
--- a/enclave.go
+++ b/enclave.go
@@ -189,8 +189,8 @@ func NewEnclave(cfg *Config) (*Enclave, error) {
 	// critical to boosting the requests per second that our reverse proxy can
 	// sustain.  See the following comment for more details:
 	// https://github.com/brave/nitriding-daemon/issues/2#issuecomment-1530245059
-	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = 100
-	http.DefaultTransport.(*http.Transport).MaxIdleConns = 100
+	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = 500
+	http.DefaultTransport.(*http.Transport).MaxIdleConns = 500
 
 	if cfg.Debug {
 		e.pubSrv.Handler.(*chi.Mux).Use(middleware.Logger)

--- a/proxy.go
+++ b/proxy.go
@@ -14,11 +14,11 @@ import (
 	"github.com/containers/gvisor-tap-vsock/pkg/transport"
 	"github.com/songgao/water"
 	"github.com/vishvananda/netlink"
-	"gvisor.dev/gvisor/pkg/tcpip/header"
 )
 
 var (
-	mtu = 4000
+	frameLen     = 0xffff
+	frameSizeLen = 2
 )
 
 // runNetworking calls the function that sets up our networking environment.
@@ -91,8 +91,8 @@ func setupNetworking(c *Config, stop chan bool) error {
 
 	// Spawn goroutines that forward traffic.
 	errCh := make(chan error, 1)
-	go tx(conn, tap, errCh, mtu)
-	go rx(conn, tap, errCh, mtu)
+	go tx(conn, tap, errCh)
+	go rx(conn, tap, errCh)
 	elog.Println("Started goroutines to forward traffic.")
 	select {
 	case err := <-errCh:
@@ -121,54 +121,64 @@ func linkUp() error {
 	return netlink.LinkSetUp(link)
 }
 
-func rx(conn net.Conn, tap *water.Interface, errCh chan error, mtu int) {
+func rx(conn net.Conn, tap *water.Interface, errCh chan error) {
 	elog.Println("Waiting for frames from enclave application.")
-	frame := make([]byte, mtu)
-	size := make([]byte, 2)
+	buf := make([]byte, frameSizeLen+frameLen) // Two bytes for the frame length plus the frame itself
+
 	for {
-		n, err := tap.Read([]byte(frame))
+		n, err := tap.Read([]byte(buf[frameSizeLen:]))
 		if err != nil {
-			errCh <- fmt.Errorf("failed to read packet from TAP device: %w", err)
+			errCh <- fmt.Errorf("failed to read payload from enclave application: %w", err)
 			return
 		}
 
-		binary.LittleEndian.PutUint16(size, uint16(n))
-		if _, err := conn.Write(append(size, frame[:n]...)); err != nil {
-			errCh <- fmt.Errorf("failed to write size and frame to connection: %w", err)
+		binary.LittleEndian.PutUint16(buf[:frameSizeLen], uint16(n))
+		m, err := conn.Write(buf[:frameSizeLen+n])
+		if err != nil {
+			errCh <- fmt.Errorf("failed to write payload to host: %w", err)
+			return
+		}
+		m = m - frameSizeLen
+		if m != n {
+			errCh <- fmt.Errorf("wrote %d instead of %d bytes to host", m, n)
 			return
 		}
 	}
 }
 
-func tx(conn net.Conn, tap *water.Interface, errCh chan error, mtu int) {
+func tx(conn net.Conn, tap *water.Interface, errCh chan error) {
 	elog.Println("Waiting for frames from host.")
-	size := make([]byte, 2)
-	buf := make([]byte, mtu+header.EthernetMinimumSize)
+	buf := make([]byte, frameSizeLen+frameLen) // Two bytes for the frame length plus the frame itself
 
 	for {
-		n, err := io.ReadFull(conn, size)
+		n, err := io.ReadFull(conn, buf[:frameSizeLen])
 		if err != nil {
-			errCh <- fmt.Errorf("failed to read frame size from connection: %w", err)
+			errCh <- fmt.Errorf("failed to read length from host: %w", err)
 			return
 		}
-		if n != 2 {
-			errCh <- fmt.Errorf("received unexpected frame size %d", n)
+		if n != frameSizeLen {
+			errCh <- fmt.Errorf("received unexpected length %d", n)
 			return
 		}
-		size := int(binary.LittleEndian.Uint16(size[0:2]))
+		size := int(binary.LittleEndian.Uint16(buf[:frameSizeLen]))
 
-		n, err = io.ReadFull(conn, buf[:size])
+		n, err = io.ReadFull(conn, buf[frameSizeLen:size+frameSizeLen])
 		if err != nil {
-			errCh <- fmt.Errorf("failed to read frame from connection: %w", err)
+			errCh <- fmt.Errorf("failed to read payload from host: %w", err)
 			return
 		}
 		if n == 0 || n != size {
-			errCh <- fmt.Errorf("expected frame of size %d but got %d", size, n)
+			errCh <- fmt.Errorf("expected payload of size %d but got %d", size, n)
 			return
 		}
 
-		if _, err := tap.Write(buf[:size]); err != nil {
-			errCh <- fmt.Errorf("failed to write frame to TAP device: %w", err)
+		m, err := tap.Write(buf[frameSizeLen : n+frameSizeLen])
+		if err != nil {
+			errCh <- fmt.Errorf("failed to write payload to enclave application: %w", err)
+			return
+		}
+		if m != n {
+			errCh <- fmt.Errorf("wrote %d instead of %d bytes to host", m, n)
 			return
 		}
 	}


### PR DESCRIPTION
This commit improves the performance of the rx and tx loop by 1) moving allocations to outside the loop and by 2) eliminating an unnecessary Write call.

As long as gvproxy implements the same improvements, this should result in ~20% more reqs/sec.

For posterity, here's the upstream PR for the gvproxy side of things: https://github.com/containers/gvisor-tap-vsock/pull/215