### PR TITLE
Make Prometheus namespace configurable.

### DIFF
--- a/enclave.go
+++ b/enclave.go
@@ -102,6 +102,10 @@ type Config struct {
 	// information and are safe to export in production.
 	PrometheusPort uint16
 
+	// PrometheusNamespace specifies the namespace for exported Prometheus
+	// metrics.  Consider setting this to your application's name.
+	PrometheusNamespace string
+
 	// UseProfiling enables profiling via pprof.  Profiling information will be
 	// available at /enclave/debug.  Note that profiling data is privacy
 	// sensitive and therefore must not be enabled in production.
@@ -194,7 +198,7 @@ func NewEnclave(cfg *Config) (*Enclave, error) {
 			Handler: promhttp.HandlerFor(reg, promhttp.HandlerOpts{Registry: reg}),
 		},
 		promRegistry: reg,
-		metrics:      newMetrics(reg),
+		metrics:      newMetrics(reg, cfg.PrometheusNamespace),
 		nonceCache:   newCache(defaultItemExpiry),
 		hashes:       new(AttestationHashes),
 		stop:         make(chan bool),

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func init() {
 }
 
 func main() {
-	var fqdn, appURL, appWebSrv, appCmd string
+	var fqdn, appURL, appWebSrv, appCmd, prometheusNamespace string
 	var extPort, intPort, hostProxyPort, prometheusPort uint
 	var useACME, waitForApp, useProfiling, debug bool
 	var err error
@@ -46,6 +46,8 @@ func main() {
 		"Enclave-internal HTTP server of the enclave application (e.g., \"http://127.0.0.1:8081\").")
 	flag.StringVar(&appCmd, "appcmd", "",
 		"Launch enclave application via the given command.")
+	flag.StringVar(&prometheusNamespace, "prometheus-namespace", "",
+		"Prometheus namespace for exported metrics.")
 	flag.UintVar(&extPort, "extport", 443,
 		"Nitriding's VSOCK-facing HTTPS port.  Must match port forwarding rules on EC2 host.")
 	flag.UintVar(&intPort, "intport", 8080,
@@ -79,17 +81,21 @@ func main() {
 	if prometheusPort > math.MaxUint16 {
 		elog.Fatalf("-prometheus-port must be in interval [1, %d]", math.MaxUint16)
 	}
+	if prometheusPort != 0 && prometheusNamespace == "" {
+		elog.Fatalf("-prometheus-namespace must be set when Prometheus is used.")
+	}
 
 	c := &Config{
-		FQDN:           fqdn,
-		ExtPort:        uint16(extPort),
-		IntPort:        uint16(intPort),
-		PrometheusPort: uint16(prometheusPort),
-		HostProxyPort:  uint32(hostProxyPort),
-		UseACME:        useACME,
-		WaitForApp:     waitForApp,
-		UseProfiling:   useProfiling,
-		Debug:          debug,
+		FQDN:                fqdn,
+		ExtPort:             uint16(extPort),
+		IntPort:             uint16(intPort),
+		PrometheusPort:      uint16(prometheusPort),
+		PrometheusNamespace: prometheusNamespace,
+		HostProxyPort:       uint32(hostProxyPort),
+		UseACME:             useACME,
+		WaitForApp:          waitForApp,
+		UseProfiling:        useProfiling,
+		Debug:               debug,
 	}
 	if appURL != "" {
 		u, err := url.Parse(appURL)

--- a/metrics.go
+++ b/metrics.go
@@ -16,7 +16,6 @@ const (
 	respErr    = "http_resp_error"
 
 	notAvailable = "n/a"
-	namespace    = "nitriding"
 )
 
 // metrics contains our Prometheus metrics.
@@ -26,7 +25,8 @@ type metrics struct {
 }
 
 // newMetrics initializes our Prometheus metrics.
-func newMetrics(reg prometheus.Registerer) *metrics {
+func newMetrics(reg prometheus.Registerer, namespace string) *metrics {
+	elog.Printf("Initializing Prometheus metrics for %q.", namespace)
 	m := &metrics{
 		reqs: prometheus.NewCounterVec(
 			prometheus.CounterOpts{

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -71,7 +71,7 @@ func TestMetrics(t *testing.T) {
 	expectedPath := "/foo"
 	expectedMethod := http.MethodGet
 	reg := prometheus.NewRegistry()
-	m := newMetrics(reg)
+	m := newMetrics(reg, "nitriding")
 	req, err := http.NewRequest(expectedMethod, expectedPath, nil)
 	if err != nil {
 		t.Fatalf("Failed to create new HTTP request: %v", err)


### PR DESCRIPTION
So far, nitriding would always use the namespace "nitriding".  That's not great; especially when managing multiple enclave applications.  This commit exposes a new command line flag to make the namespace configurable.

This fixes https://github.com/brave/nitriding-daemon/issues/22.