### PR TITLE
Configure our namespace in the process collector.

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -48,7 +48,9 @@ func newMetrics(reg prometheus.Registerer, namespace string) *metrics {
 	reg.MustRegister(m.proxiedReqs)
 	reg.MustRegister(m.reqs)
 
-	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{
+		Namespace: namespace,
+	}))
 	reg.MustRegister(collectors.NewGoCollector())
 
 	return m


### PR DESCRIPTION
I forgot to set the custom namespace in the process collector. One should not do that for the Go collector because [these metrics are supposed to be shared across all Go executables](https://github.com/prometheus/client_golang/issues/782#issuecomment-660974222).