### PR TITLE
Add mock certificate fingerprint setting

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func init() {
 }
 
 func main() {
-	var fqdn, appURL, appWebSrv, appCmd, prometheusNamespace string
+	var fqdn, appURL, appWebSrv, appCmd, prometheusNamespace, mockCertFp string
 	var extPort, intPort, hostProxyPort, prometheusPort uint
 	var useACME, waitForApp, useProfiling, useVsockForExtPort, disableKeepAlives, debug bool
 	var err error
@@ -68,6 +68,8 @@ func main() {
 		"Start Internet-facing Web server only after application signals its readiness.")
 	flag.BoolVar(&debug, "debug", false,
 		"Print debug messages.")
+	flag.StringVar(&mockCertFp, "mock-cert-fp", "",
+		"Mock certificate fingerprint to use in attestation documents (hexadecimal)")
 	flag.Parse()
 
 	if fqdn == "" {
@@ -101,6 +103,7 @@ func main() {
 		UseACME:             useACME,
 		WaitForApp:          waitForApp,
 		UseProfiling:        useProfiling,
+		MockCertFp:          mockCertFp,
 		Debug:               debug,
 	}
 	if appURL != "" {


### PR DESCRIPTION
Recently, we rolled out a Griffin feature to disable attestation in the browser. However, only 50% of our users have migrated to browser versions that include the change. We will need to add a fingerprint certificate setting so we can use the FP of our typical "*.bsg.brave.com" certificate to "fool" old clients into thinking that the randomness server is in an enclave.