### PR TITLE
Add support for arm64 builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ godeps = *.go go.mod go.sum
 cover_out = cover.out
 cover_html = cover.html
 
+ARCH ?= amd64
+
 all: lint test $(binary)
 
 .PHONY: lint
@@ -24,7 +26,7 @@ $(cover_html): $(cover_out)
 	go tool cover -html=$(cover_out) -o $(cover_html)
 
 $(binary): $(godeps)
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -buildvcs=false -o $(binary)
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -trimpath -ldflags="-s -w" -buildvcs=false -o $(binary)
 
 .PHONY: clean
 clean:

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -6,7 +6,8 @@ WORKDIR /
 
 # Clone the repository and build the stand-alone nitriding executable.
 RUN git clone https://github.com/brave/nitriding-daemon.git
-RUN make -C nitriding-daemon/ nitriding
+ARG TARGETARCH
+RUN ARCH=${TARGETARCH} make -C nitriding-daemon/ nitriding
 
 # Use the intermediate builder image to add our files.  This is necessary to
 # avoid intermediate layers that contain inconsistent file permissions.

--- a/example/Makefile
+++ b/example/Makefile
@@ -4,6 +4,14 @@ image_tag := $(prog):$(version)
 image_tar := $(prog)-$(version)-kaniko.tar
 image_eif := $(image_tar:%.tar=%.eif)
 
+ARCH ?= $(shell uname -m)
+ifeq ($(ARCH),aarch64)
+	override ARCH=arm64
+endif
+ifeq ($(ARCH),x86_64)
+	override ARCH=amd64
+endif
+
 .PHONY: all
 all: run
 
@@ -13,12 +21,15 @@ image: $(image_tar)
 $(image_tar): Dockerfile service.py start.sh
 	docker run \
 		-v $(PWD):/workspace \
-		gcr.io/kaniko-project/executor:v1.9.2 \
+		gcr.io/kaniko-project/executor:v1.19.2 \
 		--reproducible \
 		--no-push \
 		--tarPath $(image_tar) \
 		--destination $(image_tag) \
-		--custom-platform linux/amd64
+		--build-arg TARGETPLATFORM=linux/$(ARCH) \
+		--build-arg TARGETOS=linux \
+		--build-arg TARGETARCH=$(ARCH) \
+		--custom-platform linux/$(ARCH)
 
 $(image_eif): $(image_tar)
 	docker load -i $<

--- a/example/Makefile
+++ b/example/Makefile
@@ -21,7 +21,7 @@ image: $(image_tar)
 $(image_tar): Dockerfile service.py start.sh
 	docker run \
 		-v $(PWD):/workspace \
-		gcr.io/kaniko-project/executor:v1.19.2 \
+		gcr.io/kaniko-project/executor:v1.9.2 \
 		--reproducible \
 		--no-push \
 		--tarPath $(image_tar) \


### PR DESCRIPTION
Rather than forcing nitriding to build against the amd64 architecture, support arm64 builds by allowing the `ARCH` environment variable to override the build architecture.

Also, update the example to automatically choose the build architecture based on the architecture of the machine where the example is built and run.