### PR TITLE
Update example scripts

### DIFF
--- a/example/run-enclave.sh
+++ b/example/run-enclave.sh
@@ -27,4 +27,4 @@ nitro-cli run-enclave \
 	--attach-console
 
 echo "[ec2] Stopping gvproxy."
-sudo pkill -INT -P "$pid"
+sudo kill -INT "$pid"

--- a/example/start.sh
+++ b/example/start.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-nitriding -fqdn example.com -extport 443 -intport 8080 &
+nitriding -fqdn example.com -ext-pub-port 443 -intport 8080 -wait-for-app &
 echo "[sh] Started nitriding."
 
 sleep 1


### PR DESCRIPTION
* Update nitriding command in `start.sh` to match current argument naming.
* Replace `pkill` with `kill` as `pkill` is unnecessary and not always available.