### PR TITLE
docs: fix link to usage.md from setup.md

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -39,4 +39,4 @@ sudo systemctl enable nitro-enclaves-allocator.service
 sudo yum -y install golang
 ```
 
-For next steps go [here](/usage.md)
+For next steps go [here](./usage.md)


### PR DESCRIPTION
Quick documentation fix for an incorrect link to `doc/usage.md` from `doc/setup.md` (linked out to a 404).