### PR TITLE
Verify only Identity PCRs during key synchronization

### DIFF
--- a/attestation.go
+++ b/attestation.go
@@ -27,6 +27,18 @@ var (
 	// values.  Using a variable allows us to easily mock the function in our
 	// unit tests.
 	getPCRValues = func() (map[uint][]byte, error) { return _getPCRValues() }
+
+	// identityPCRs contains the PCR indices that AWS Nitro Enclaves populates:
+	// https://docs.aws.amazon.com/enclaves/latest/user/set-up-attestation.html
+	//   - PCR0: Enclave image file
+	//   - PCR1: Linux kernel and bootstrap
+	//   - PCR2: Application
+	//   - PCR3: IAM role assigned to the parent instance
+	//   - PCR8: Enclave image file signing certificate
+	//
+	// PCR4 (parent instance ID) is excluded because enclaves run on different
+	// parent instances during horizontal scaling.
+	identityPCRs = [...]uint{0, 1, 2, 3, 8}
 )
 
 // AttestationHashes contains hashes over public key material which we embed in
@@ -62,22 +74,13 @@ func _getPCRValues() (map[uint][]byte, error) {
 	return res.Document.PCRs, nil
 }
 
-// arePCRsIdentical returns true if (and only if) the two given PCR maps are
-// identical.
+// arePCRsIdentical returns true if (and only if) the two given PCR maps
+// contain identical values for the Nitro Enclave-populated PCRs.
 func arePCRsIdentical(ourPCRs, theirPCRs map[uint][]byte) bool {
-	if len(ourPCRs) != len(theirPCRs) {
-		return false
-	}
-
-	for pcr, ourValue := range ourPCRs {
-		// PCR4 contains a hash over the parent's instance ID.  Our enclaves run
-		// on different parent instances; PCR4 will therefore always differ:
-		// https://docs.aws.amazon.com/enclaves/latest/user/set-up-attestation.html
-		if pcr == 4 {
-			continue
-		}
-		theirValue, exists := theirPCRs[pcr]
-		if !exists {
+	for _, pcr := range identityPCRs {
+		ourValue, ourExists := ourPCRs[pcr]
+		theirValue, theirExists := theirPCRs[pcr]
+		if ourExists != theirExists {
 			return false
 		}
 		if !bytes.Equal(ourValue, theirValue) {

--- a/attestation_test.go
+++ b/attestation_test.go
@@ -10,32 +10,48 @@ import (
 )
 
 func TestArePCRsIdentical(t *testing.T) {
-	pcr1 := map[uint][]byte{
-		1: []byte("foobar"),
+	// Helper to create a PCR map with all identity PCRs set to the same value.
+	makePCRs := func(val []byte) map[uint][]byte {
+		m := make(map[uint][]byte)
+		for _, pcr := range identityPCRs {
+			m[pcr] = append([]byte{}, val...)
+		}
+		return m
 	}
-	pcr2 := map[uint][]byte{
-		1: []byte("foobar"),
-	}
+
+	pcr1 := makePCRs([]byte("foobar"))
+	pcr2 := makePCRs([]byte("foobar"))
 	if !arePCRsIdentical(pcr1, pcr2) {
 		t.Fatal("Failed to recognize identical PCRs as such.")
 	}
 
-	// PCR4 should be ignored.
-	pcr1[4], pcr2[4] = []byte("foo"), []byte("bar")
+	// All non-identity PCRs (0–31) should be ignored, even when they differ
+	// between the two maps.
+	isIdentityPCR := make(map[uint]bool)
+	for _, pcr := range identityPCRs {
+		isIdentityPCR[pcr] = true
+	}
+	for i := uint(0); i < 32; i++ {
+		if isIdentityPCR[i] {
+			continue
+		}
+		pcr1[i] = []byte("foo")
+		pcr2[i] = []byte("bar")
+	}
 	if !arePCRsIdentical(pcr1, pcr2) {
-		t.Fatal("Failed to recognize identical PCRs as such.")
+		t.Fatal("Non-identity PCRs should be ignored.")
 	}
 
-	// Add a new PCR value, so our two maps are no longer identical.
-	pcr1[2] = []byte("barfoo")
+	// Changing an identity PCR should cause a mismatch.
+	pcr1[2] = []byte("different")
 	if arePCRsIdentical(pcr1, pcr2) {
 		t.Fatal("Failed to recognize different PCRs as such.")
 	}
 
-	// Add the same PCR ID but with a different value.
-	pcr2[2] = []byte("foobar")
+	// A missing identity PCR in one map should cause a mismatch.
+	delete(pcr1, 2)
 	if arePCRsIdentical(pcr1, pcr2) {
-		t.Fatal("Failed to recognize different PCRs as such.")
+		t.Fatal("Failed to recognize missing PCR as mismatch.")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Restrict PCR verification during key synchronization to only the AWS Nitro Enclave-defined PCRs (0, 1, 2, 3, 8),
- Update tests to cover the new behavior including non-Identity PCR indices being ignored

## Motivation

The previous `arePCRsIdentical` implementation compared **every** PCR present in the attestation document. This is problematic because:

1. **Map length check breaks custom PCRs.** The old code started with `len(ourPCRs) != len(theirPCRs)` — if one enclave's attestation document happened to include a different set of PCR indices than another (e.g., the hypervisor populates an additional register on a newer host), synchronization would fail immediately before any values were even compared.

2. **Custom PCRs are not meaningful for identity verification.** PCRs outside the AWS-defined set (0–4, 8) are either unused/zero-filled or could contain host-specific data. Comparing them adds no security value and creates false negatives.

3. **PCR4 was a special case hinting at a broader problem.** The old code already had to skip PCR4 because it contains the parent instance ID. But rather than treating this as a one-off exception, the fix addresses the root issue: only the PCRs that attest to enclave identity (image, kernel, application, IAM role, signing cert) should be verified.