### PR TITLE
fix: wait for output goroutines before exiting runAppCommand

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 )
 
 var (
@@ -174,18 +175,31 @@ func runAppCommand(appCmd string, stdoutFunc, stderrFunc func(string)) {
 	if err != nil {
 		elog.Fatalf("Failed to obtain stderr pipe for enclave application: %v", err)
 	}
-	go forwardOutput(stderr, stderrFunc, "stderr")
 
 	// Print the enclave application's stdout.
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		elog.Fatalf("Failed to obtain stdout pipe for enclave application: %v", err)
 	}
-	go forwardOutput(stdout, stdoutFunc, "stdout")
+
+	// Wait for the output goroutines to drain before calling cmd.Wait, which
+	// closes the pipes. Otherwise, fast-exiting applications can lose output.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		forwardOutput(stderr, stderrFunc, "stderr")
+	}()
+	go func() {
+		defer wg.Done()
+		forwardOutput(stdout, stdoutFunc, "stdout")
+	}()
 
 	if err := cmd.Start(); err != nil {
 		elog.Fatalf("Failed to start enclave application: %v", err)
 	}
+
+	wg.Wait()
 
 	if err := cmd.Wait(); err != nil {
 		elog.Fatalf("Enclave application exited with non-0 exit code: %v", err)

--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestSpawnAppProcess(t *testing.T) {
@@ -22,5 +26,53 @@ func TestSpawnAppProcess(t *testing.T) {
 		if output[i] != expected[i] {
 			t.Fatalf("Expected element at index %d to be %s but got %s.", i, expected[i], output[i])
 		}
+	}
+}
+
+// TestSpawnAppProcessWaitsForOutput verifies that runAppCommand does not return
+// until every line written by the application has been delivered to the
+// callback. Regression test for issue #39.
+//
+// The test exercises the race between cmd.Wait closing the read end of the
+// stdout/stderr pipes and the forwarder goroutines iterating through lines
+// already buffered by bufio.Scanner. Once the process exits, cmd.Wait can
+// return quickly while the goroutines are still draining buffered lines into
+// the (intentionally slow) callback. Without a sync.WaitGroup gating the
+// return on the goroutines, runAppCommand returns prematurely.
+func TestSpawnAppProcessWaitsForOutput(t *testing.T) {
+	const stdoutLines = 50
+	const stderrLines = 50
+	const perLineDelay = 5 * time.Millisecond
+
+	script := filepath.Join(t.TempDir(), "burst.sh")
+	var body strings.Builder
+	body.WriteString("#!/bin/sh\n")
+	for range stdoutLines {
+		body.WriteString("echo out\n")
+	}
+	for range stderrLines {
+		body.WriteString("echo err >&2\n")
+	}
+	if err := os.WriteFile(script, []byte(body.String()), 0o755); err != nil {
+		t.Fatalf("failed to write script: %v", err)
+	}
+
+	var stdout, stderr atomic.Int32
+	slowStdout := func(string) {
+		time.Sleep(perLineDelay)
+		stdout.Add(1)
+	}
+	slowStderr := func(string) {
+		time.Sleep(perLineDelay)
+		stderr.Add(1)
+	}
+
+	runAppCommand(script, slowStdout, slowStderr)
+
+	if got := stdout.Load(); got != stdoutLines {
+		t.Fatalf("runAppCommand returned with stdout output still pending: got %d/%d lines", got, stdoutLines)
+	}
+	if got := stderr.Load(); got != stderrLines {
+		t.Fatalf("runAppCommand returned with stderr output still pending: got %d/%d lines", got, stderrLines)
 	}
 }


### PR DESCRIPTION
The forwarders reading the application's stdout and stderr were spawned as fire-and-forget goroutines, so cmd.Wait could close the pipe read ends (and elog.Fatalf could call os.Exit on a non-zero exit code) while buffered output was still in flight. This resulted in missing application logs on exit.

Gate the return on a sync.WaitGroup so all output is delivered to the callbacks before cmd.Wait runs.

fixes #39