### PR TITLE
feat: configurable resolv.conf search domains and ndots

### DIFF
--- a/enclave.go
+++ b/enclave.go
@@ -185,6 +185,15 @@ type Config struct {
 	// MockCertFp specifies a mock TLS certificate fingerprint
 	// to use in attestation documents.
 	MockCertFp string
+
+	// ResolvSearch is the space-separated list of DNS search domains written
+	// to the enclave's resolv.conf "search" line.  If empty, no search line
+	// is emitted.
+	ResolvSearch string
+
+	// ResolvNdots is the value written to the enclave's resolv.conf
+	// "options ndots:N" line.  If zero, no options line is emitted.
+	ResolvNdots uint8
 }
 
 // Validate returns an error if required fields in the config are not set.

--- a/main.go
+++ b/main.go
@@ -33,8 +33,8 @@ func init() {
 }
 
 func main() {
-	var fqdn, fqdnLeader, appURL, appWebSrv, appCmd, prometheusNamespace, mockCertFp string
-	var extPubPort, extPrivPort, intPort, hostProxyPort, prometheusPort uint
+	var fqdn, fqdnLeader, appURL, appWebSrv, appCmd, prometheusNamespace, mockCertFp, resolvSearch string
+	var extPubPort, extPrivPort, intPort, hostProxyPort, prometheusPort, resolvNdots uint
 	var useACME, waitForApp, useProfiling, useVsockForExtPort, disableKeepAlives, debug bool
 	var err error
 
@@ -74,6 +74,10 @@ func main() {
 		"Print extra debug messages and use dummy attester for testing outside enclaves.")
 	flag.StringVar(&mockCertFp, "mock-cert-fp", "",
 		"Mock certificate fingerprint to use in attestation documents (hexadecimal)")
+	flag.StringVar(&resolvSearch, "resolv-search", "",
+		"Space-separated DNS search domains to write to the enclave's resolv.conf (e.g., \"foo.internal bar.internal\").")
+	flag.UintVar(&resolvNdots, "resolv-ndots", 0,
+		"Value for the resolv.conf \"options ndots:N\" line.  If 0, no options line is written.")
 	flag.Parse()
 
 	if fqdn == "" {
@@ -97,6 +101,9 @@ func main() {
 	if prometheusPort != 0 && prometheusNamespace == "" {
 		elog.Fatalf("-prometheus-namespace must be set when Prometheus is used.")
 	}
+	if resolvNdots > 15 {
+		elog.Fatalf("-resolv-ndots must be in interval [0, 15].")
+	}
 
 	c := &Config{
 		FQDN:                fqdn,
@@ -114,6 +121,8 @@ func main() {
 		UseProfiling:        useProfiling,
 		MockCertFp:          mockCertFp,
 		Debug:               debug,
+		ResolvSearch:        resolvSearch,
+		ResolvNdots:         uint8(resolvNdots),
 	}
 	if appURL != "" {
 		u, err := url.Parse(appURL)

--- a/proxy.go
+++ b/proxy.go
@@ -75,7 +75,7 @@ func setupNetworking(c *Config, stop chan struct{}) error {
 	if err = configureTapIface(); err != nil {
 		return fmt.Errorf("failed to configure tap interface: %w", err)
 	}
-	if err = writeResolvconf(); err != nil {
+	if err = writeResolvconf(c); err != nil {
 		return fmt.Errorf("failed to create resolv.conf: %w", err)
 	}
 

--- a/system_darwin.go
+++ b/system_darwin.go
@@ -8,5 +8,5 @@ var ourWaterParams = water.PlatformSpecificParams{Name: ifaceTap}
 // functions, we can at least get it to compile.
 func configureLoIface() error  { return nil }
 func configureTapIface() error { return nil }
-func writeResolvconf() error   { return nil }
+func writeResolvconf(_ *Config) error { return nil }
 func maybeSeedEntropy()        {}

--- a/system_darwin_test.go
+++ b/system_darwin_test.go
@@ -5,5 +5,5 @@ import "testing"
 func TestNetworking(t *testing.T) {
 	assertEqual(t, configureLoIface(), nil)
 	assertEqual(t, configureTapIface(), nil)
-	assertEqual(t, writeResolvconf(), nil)
+	assertEqual(t, writeResolvconf(&Config{}), nil)
 }

--- a/system_linux.go
+++ b/system_linux.go
@@ -77,21 +77,31 @@ func configureTapIface() error {
 	return nil
 }
 
-// writeResolvconf creates our resolv.conf and adds a nameserver.
-func writeResolvconf() error {
+// resolvconfDir is the directory holding the enclave's resolv.conf.  It is a
+// var so tests can override it.
+var resolvconfDir = "/run/resolvconf/"
+
+// writeResolvconf creates our resolv.conf and adds a nameserver.  When
+// configured, it also writes "search" and "options ndots:N" lines.
+func writeResolvconf(c *Config) error {
 	// A Nitro Enclave's /etc/resolv.conf is a symlink to
 	// /run/resolvconf/resolv.conf.  As of 2022-11-21, the /run/ directory
 	// exists but not its resolvconf/ subdirectory.
-	dir := "/run/resolvconf/"
-	file := dir + "resolv.conf"
-
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(resolvconfDir, 0755); err != nil {
 		return fmt.Errorf("failed to create directories: %w", err)
 	}
 
 	// Our default gateway -- gvproxy -- also operates a DNS resolver.
-	c := fmt.Sprintf("nameserver %s\n", defaultGw)
-	if err := os.WriteFile(file, []byte(c), 0644); err != nil {
+	out := fmt.Sprintf("nameserver %s\n", defaultGw)
+	if c.ResolvSearch != "" {
+		out += fmt.Sprintf("search %s\n", c.ResolvSearch)
+	}
+	if c.ResolvNdots > 0 {
+		out += fmt.Sprintf("options ndots:%d\n", c.ResolvNdots)
+	}
+
+	file := resolvconfDir + "resolv.conf"
+	if err := os.WriteFile(file, []byte(out), 0644); err != nil {
 		return fmt.Errorf("failed to write file: %w", err)
 	}
 

--- a/system_linux_test.go
+++ b/system_linux_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestWriteResolvconf(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{
+			name: "nameserver only",
+			cfg:  Config{},
+			want: "nameserver " + defaultGw + "\n",
+		},
+		{
+			name: "with search",
+			cfg:  Config{ResolvSearch: "foo.internal bar.internal"},
+			want: "nameserver " + defaultGw + "\n" +
+				"search foo.internal bar.internal\n",
+		},
+		{
+			name: "with ndots",
+			cfg:  Config{ResolvNdots: 2},
+			want: "nameserver " + defaultGw + "\n" +
+				"options ndots:2\n",
+		},
+		{
+			name: "with search and ndots",
+			cfg: Config{
+				ResolvSearch: "foo.internal",
+				ResolvNdots:  5,
+			},
+			want: "nameserver " + defaultGw + "\n" +
+				"search foo.internal\n" +
+				"options ndots:5\n",
+		},
+	}
+
+	origDir := resolvconfDir
+	t.Cleanup(func() { resolvconfDir = origDir })
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resolvconfDir = t.TempDir() + "/"
+
+			if err := writeResolvconf(&tc.cfg); err != nil {
+				t.Fatalf("writeResolvconf: %v", err)
+			}
+
+			got, err := os.ReadFile(resolvconfDir + "resolv.conf")
+			if err != nil {
+				t.Fatalf("ReadFile: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("got:\n%q\nwant:\n%q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add -resolv-search and -resolv-ndots flags so operators can populate the enclave's resolv.conf with DNS search domains and an ndots option at launch time. Without these, the enclave's resolv.conf only carried a nameserver line, which broke short-name and subdomain resolution in deployments that rely on host search domains.